### PR TITLE
Fix login redirect runtime error (hard navigate to same URL)

### DIFF
--- a/FruverReactFront/src/pages/_app.js
+++ b/FruverReactFront/src/pages/_app.js
@@ -11,7 +11,7 @@ function ProtectedRoute({ children }) {
 
   useEffect(() => {
     if (!loading && !user && router.pathname !== '/login') {
-      router.replace('/login');
+      router.replace('/login').catch(() => {});
     }
   }, [user, loading, router.pathname]);
 

--- a/FruverReactFront/src/pages/login.jsx
+++ b/FruverReactFront/src/pages/login.jsx
@@ -13,9 +13,9 @@ export default function Login() {
 
   useEffect(() => {
     if (user) {
-      router.replace('/');
+      router.replace('/').catch(() => {});
     }
-  }, [user, router.pathname]);
+  }, [user]);
 
   useEffect(() => {
     // Inicializar admin por defecto si no existe


### PR DESCRIPTION
## Summary

Fixes the "Invariant: attempted to hard navigate to the same URL /login" runtime error that appears on the deployed app. Adds `.catch(() => {})` to `router.replace()` calls in both the auth guard (`_app.js`) and the login page redirect (`login.jsx`).

Also narrows the useEffect dependency in `login.jsx` from `[user, router.pathname]` to `[user]` since the redirect only depends on user state.

## Review & Testing Checklist for Human

- [ ] **Verify that silently catching all navigation errors is acceptable** — the `.catch(() => {})` swallows every routing error, not just the "same URL" invariant. If a legitimate navigation failure occurs (e.g., a page doesn't exist), it will be silently ignored. Consider whether logging the error or checking the error type would be safer.
- [ ] **Test the full login/logout flow on the deployed tunnel** — the error only reproduces on the deployed version (with the proxy/tunnel), not on localhost. Verify: (1) open `/login` directly while unauthenticated → no error overlay, (2) enter PIN → redirects to `/`, (3) log out → redirects back to `/login` without error.
- [ ] **Confirm the dependency array change doesn't break edge cases** — `login.jsx` useEffect changed from `[user, router.pathname]` to `[user]`. Verify that navigating to `/login` while already authenticated still correctly redirects to `/`.

### Notes
- The root cause appears to be Next.js Pages Router throwing when `router.replace` is called for a URL matching the current location, possibly due to timing with the tunnel proxy. The `.catch()` is a pragmatic workaround rather than a root-cause fix.
- Link to Devin run: https://app.devin.ai/sessions/904d74686ea64734991b56484ecf9559
- Requested by: @sergiomvp10