### PR TITLE
Agregar columna Método de Pago (EFECTIVO/BRE-B) en venta detallada

### DIFF
--- a/FruverNodeBack/src/controllers/sale.controller.js
+++ b/FruverNodeBack/src/controllers/sale.controller.js
@@ -296,7 +296,8 @@ export const getSalesWithDetails = async (req, res, next) => {
         i.price_sale as precioVenta,
         (i.price_sale * i.amount) as subtotal,
         datetime(i.createdAt) as fechaHora,
-        u.name as vendedor
+        u.name as vendedor,
+        s.paymentMethod as metodoPago
        FROM ItemSales i
        LEFT JOIN Products p ON i.ProductId = p.id
        LEFT JOIN Sales s ON i.SaleId = s.id

--- a/FruverReactFront/src/pages/sales.jsx
+++ b/FruverReactFront/src/pages/sales.jsx
@@ -197,6 +197,7 @@ const Sales = () => {
                             <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Precio Unit.</th>
                             <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Subtotal</th>
                             <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Vendedor</th>
+                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Pago</th>
                             <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Venta #</th>
                           </tr>
                         </thead>
@@ -220,6 +221,9 @@ const Sales = () => {
                               </td>
                               <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
                                 {item.vendedor || 'Sin asignar'}
+                              </td>
+                              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700 font-medium">
+                                {item.metodoPago || 'EFECTIVO'}
                               </td>
                               <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
                                 #{item.SaleId}


### PR DESCRIPTION
## Summary

Adds a "Pago" (payment method) column to the detailed sales table, showing whether each sale was paid via EFECTIVO or BRE-B. The backend query now also selects `s.paymentMethod` from the already-joined `Sales` table, and the frontend renders it in a new column.

## Review & Testing Checklist for Human

- [ ] **Verify the fallback value is acceptable** — if `paymentMethod` is NULL in the database (e.g. older sales), it defaults to displaying "EFECTIVO". Confirm this matches your business expectation for historical data.
- [ ] **Test the detailed sales view end-to-end** — go to Ventas → double-click a day → confirm the "Pago" column shows the correct payment method for each row, especially for sales made with BRE-B.
- [ ] **Check table layout on smaller screens** — the table now has 8 columns. Verify horizontal scroll works properly and nothing is cut off.

### Notes
- Link to Devin run: https://app.devin.ai/sessions/904d74686ea64734991b56484ecf9559
- Requested by: @sergiomvp10