### PR TITLE
Fix bug de venta fantasma: validar cantidad y agregar key props

### DIFF
--- a/FruverReactFront/src/contexts/saleContext.jsx
+++ b/FruverReactFront/src/contexts/saleContext.jsx
@@ -17,10 +17,14 @@ const SaleContextWrap = (props) => {
     amount,
     ProductId
   ) => {
-    console.log(e.key);
     if (e.key == "Enter") {
+      const parsedAmount = parseInt(amount);
+      if (!parsedAmount || parsedAmount <= 0) {
+        e.target.value = "";
+        return;
+      }
       setItemsSale([
-        { name, price_purchase, price_sale, amount, ProductId },
+        { name, price_purchase, price_sale, amount: parsedAmount, ProductId },
         ...itemsSale,
       ]);
       e.target.value = "";

--- a/FruverReactFront/src/pages/index.jsx
+++ b/FruverReactFront/src/pages/index.jsx
@@ -40,12 +40,17 @@ export default function Home() {
 
   const handleAddItem = (e, product) => {
     if (e.key === 'Enter') {
+      const amount = parseInt(e.target.value);
+      if (!amount || amount <= 0) {
+        e.target.value = '';
+        return;
+      }
       contextSale.addItemSale(
         e,
         product.name,
         product.price_purchase,
         product.price_sale,
-        e.target.value,
+        amount,
         product.id
       );
       setSearchValue('');
@@ -85,6 +90,7 @@ export default function Home() {
                         )
                         .map((product) => (
                           <ItemProduct
+                            key={product.id}
                             id={product.id}
                             name={product.name}
                             description={product.description}


### PR DESCRIPTION
## Summary

Fixes a bug where products (specifically Tomate Cherry) were being registered in sales without the user adding them. Two defensive fixes applied:

1. **Added `key={product.id}` to the product list map** — without this, React reuses DOM elements by array index when the search filter changes, which can cause uncontrolled input values to be associated with the wrong product.
2. **Added quantity validation** — `amount` is now parsed as an integer and rejected if it's empty, NaN, zero, or negative. Validation is applied in both `handleAddItem` (index.jsx) and `addItemSale` (saleContext.jsx) as defense-in-depth.

## Review & Testing Checklist for Human

- [ ] **Verify the phantom sale is actually fixed** — the root cause was not definitively reproduced, so these are defensive fixes based on code analysis. Test by: (1) typing a quantity in one product's input, (2) searching for a different product, (3) adding the searched product, (4) checking the sale list to confirm only the intended product was added. Try this several times with different products.
- [ ] **Test that normal sale flow still works** — add products with valid quantities (1, 2, 10, etc.) and confirm they appear correctly in the sale panel and get registered properly.
- [ ] **Test edge cases on the quantity input** — press Enter with empty input, "0", "-1", "abc", or "2.5" and confirm no item is added. Note that `parseInt("2.5")` will accept as 2 — verify this is acceptable behavior.
- [ ] **Confirm barcode scanner flow still works** — scan a product barcode and verify it still adds with amount=1 (this path is unchanged but worth verifying).

### Notes
- The `amount` was previously stored as a raw string from the input; it's now always stored as a parsed integer. Verify downstream consumers (e.g., the sale API, bill page) handle this correctly.
- Link to Devin run: https://app.devin.ai/sessions/904d74686ea64734991b56484ecf9559
- Requested by: @sergiomvp10